### PR TITLE
Hotfix/workers locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ The exported metrics are:
 - `kafka_consumer_records_consumed_successfully`: number of records consumed successfully by this instance.
 - `kafka_consumer_endpoint_latency_histogram_seconds`: endpoint latency in seconds (insertion to elasticsearch).
 - `kafka_consumer_buffer_full`: indicates whether the app buffer is full(meaning that elasticsearch is not being able to keep up with the topic volume).
+- `elasticsearch_events_retried`: number of events that needed to be retryed to sent to Elasticsearch
+- `elasticsearch_document_already_exists`: number of events that tryed to be inserted on elasticsearch but already existed
+- `elasticsearch_bad_request`: the number of requests that failed due to malformed events
 
 ## Development
 

--- a/src/elasticsearch/elasticsearch_test.go
+++ b/src/elasticsearch/elasticsearch_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/inloco/kafka-elasticsearch-injector/src/kafka/fixtures"
 	"github.com/inloco/kafka-elasticsearch-injector/src/logger_builder"
+	"github.com/inloco/kafka-elasticsearch-injector/src/metrics"
 	"github.com/inloco/kafka-elasticsearch-injector/src/models"
 	"github.com/olivere/elastic/v7"
 	"github.com/stretchr/testify/assert"
@@ -28,7 +29,8 @@ var config = Config{
 	BlacklistedColumns: []string{},
 	BulkTimeout:        10 * time.Second,
 }
-var db = NewDatabase(logger, config)
+
+var db = NewDatabase(logger, config, metrics.NewMetricsPublisher())
 var template = `
 {
 	"template": "my-topic-*",

--- a/src/injector/service.go
+++ b/src/injector/service.go
@@ -28,7 +28,7 @@ func NewService(logger log.Logger, metrics metrics.MetricsPublisher) Service {
 	return instrumentingMiddleware{
 		metricsPublisher: metrics,
 		next: basicService{
-			store.NewStore(logger),
+			store.NewStore(logger, metrics),
 		},
 	}
 }

--- a/src/injector/store/store.go
+++ b/src/injector/store/store.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/inloco/kafka-elasticsearch-injector/src/elasticsearch"
+	"github.com/inloco/kafka-elasticsearch-injector/src/metrics"
 	"github.com/inloco/kafka-elasticsearch-injector/src/models"
 )
 
@@ -24,6 +25,7 @@ func (s basicStore) Insert(records []*models.Record) error {
 	if err != nil {
 		return err
 	}
+
 	for {
 		res, err := s.db.Insert(elasticRecords)
 		if err != nil {
@@ -45,10 +47,10 @@ func (s basicStore) ReadinessCheck() bool {
 	return s.db.ReadinessCheck()
 }
 
-func NewStore(logger log.Logger) Store {
+func NewStore(logger log.Logger, metricsPublisher metrics.MetricsPublisher) Store {
 	config := elasticsearch.NewConfig()
 	return basicStore{
-		db:      elasticsearch.NewDatabase(logger, config),
+		db:      elasticsearch.NewDatabase(logger, config, metricsPublisher),
 		codec:   elasticsearch.NewCodec(logger, config),
 		backoff: config.Backoff,
 	}

--- a/src/kafka/consumer_test.go
+++ b/src/kafka/consumer_test.go
@@ -51,13 +51,14 @@ func (be *fixtureEndpoints) Insert() endpoint.Endpoint {
 }
 
 var (
-	logger = logger_builder.NewLogger("consumer-test")
-	config = elasticsearch.Config{
+	metricsPublisher = metrics.NewMetricsPublisher()
+	logger           = logger_builder.NewLogger("consumer-test")
+	config           = elasticsearch.Config{
 		Host:        "http://localhost:9200",
 		Index:       fixtures.DefaultTopic,
 		BulkTimeout: 10 * time.Second,
 	}
-	db        = elasticsearch.NewDatabase(logger, config)
+	db        = elasticsearch.NewDatabase(logger, config, metricsPublisher)
 	codec     = elasticsearch.NewCodec(logger, config)
 	service   = fixtureService{db, codec}
 	endpoints = &fixtureEndpoints{
@@ -90,7 +91,7 @@ func TestMain(m *testing.M) {
 		BatchSize:             1,
 		MetricsUpdateInterval: 30 * time.Second,
 	}
-	k = NewKafka("localhost:9092", consumer, metrics.NewMetricsPublisher())
+	k = NewKafka("localhost:9092", consumer, metricsPublisher)
 	retCode := m.Run()
 	os.Exit(retCode)
 }


### PR DESCRIPTION
### Description
Added a logic on elasticsearch.go Insert() method to drop requests that received http status code bad request. 
As a bonus I added 3 more metrics to give us a better look of what is going on in the communication with elasticsearch, they are: number of bad requests, number of documents retried, number of "doc already exists"

### Why is this PR needed?
It was causing a infinity loop on workers, locking the injector.
Better observability

### Checklist
- [x] Branch is named acoording to standards (`feature/*`, `fix/*`, `hotfix/*`)
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
