### PR TITLE
fix(kafka): decode union types correctly

### DIFF
--- a/src/kafka/fixtures/fixtures.go
+++ b/src/kafka/fixtures/fixtures.go
@@ -23,7 +23,7 @@ func (r *FixtureRecord) Topic() string {
 }
 
 func (r *FixtureRecord) Schema() string {
-	return `{"type": "record","name": "FixtureRecord","fields": [{"name": "id","type":"int"}]}`
+	return `{"type": "record","name": "FixtureRecord","fields": [{"name": "id","type" : [ "null", "int" ],"default" : null}]}`
 }
 
 func (r *FixtureRecord) ToAvroSerialization() ([]byte, error) {
@@ -31,7 +31,7 @@ func (r *FixtureRecord) ToAvroSerialization() ([]byte, error) {
 	if err != nil {
 		return []byte{}, nil
 	}
-	return codec.BinaryFromNative(nil, map[string]interface{}{"id": r.Id})
+	return codec.BinaryFromNative(nil, map[string]interface{}{"id": map[string]interface{}{"int": r.Id}})
 }
 
 func NewFixtureRecord() *FixtureRecord {


### PR DESCRIPTION
### Description
Some changes in goavro broke our serialization of avro's union types. We handle this by unnesting the map that goavro generates, like: `map[string]interface{}{"int": 12345}` becomes just `12345`, which is serialized into json.

### Checklist
- [x] Branch is named acoording to standards (`feature/*`, `fix/*`, `hotfix/*`)
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
